### PR TITLE
Feature/razorpay-webhooks

### DIFF
--- a/internal/trendlyapis/monetize/deliverable.go
+++ b/internal/trendlyapis/monetize/deliverable.go
@@ -134,6 +134,14 @@ func ApproveDeliverable(c *gin.Context) {
 		return
 	}
 
+	if data.Contract.Status == trendlymodels.ContractStatusPostDone {
+		err = releasePaymentAfterHoldingForDay(*data.Contract, 0)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to release payment after holding for day"})
+			return
+		}
+	}
+
 	// 2. Fetch Influencer for notification
 	influencer := &trendlymodels.User{}
 	err = influencer.Get(data.Contract.UserID)

--- a/internal/trendlyapis/monetize/deliverable.go
+++ b/internal/trendlyapis/monetize/deliverable.go
@@ -114,7 +114,12 @@ func ApproveDeliverable(c *gin.Context) {
 		}
 	case 3:
 		scenarioText = "Brand will use video independently"
-		data.Contract.Status = trendlymodels.ContractStatusPostDone
+		if data.Contract.Payment != nil && data.Contract.Payment.Status == "paid" && data.Contract.Payment.Amount == 0 {
+			data.Contract.Status = trendlymodels.ContractStatusSettled
+		} else {
+			data.Contract.Status = trendlymodels.ContractStatusPostDone
+		}
+
 	default:
 		c.JSON(http.StatusBadRequest, gin.H{"message": "Invalid posting scenario"})
 		return
@@ -140,6 +145,16 @@ func ApproveDeliverable(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to release payment after holding for day"})
 			return
 		}
+	}
+	if data.Contract.Status == trendlymodels.ContractStatusSettled {
+		if err := notifyAboutContractEnded(data.ContractID, *data.Contract); err != nil {
+			log.Printf("notify contract ended: %v", err)
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"message":         "Deliverable approved — collaboration complete",
+			"contractSettled": true,
+		})
+		return
 	}
 
 	// 2. Fetch Influencer for notification

--- a/internal/trendlyapis/monetize/order.go
+++ b/internal/trendlyapis/monetize/order.go
@@ -85,10 +85,10 @@ func CreateOrder(c *gin.Context) {
 
 		order, err := payments.CreateOrder(application.Quotation, oNotes, []payments.OrderTransfer{
 			{
-				Account:  user.KYC.AccountID,
-				Amount:   application.Quotation,
-				Currency: "INR",
-				OnHold:   myutil.BoolPtr(true),
+				Account:    user.KYC.AccountID,
+				AmountInRs: application.Quotation,
+				Currency:   "INR",
+				OnHold:     myutil.BoolPtr(true),
 			},
 		})
 		if err != nil {

--- a/internal/trendlyapis/monetize/order.go
+++ b/internal/trendlyapis/monetize/order.go
@@ -81,7 +81,7 @@ func CreateOrder(c *gin.Context) {
 			"userId":          data.Contract.UserID,
 		}
 
-		order, err := payments.CreateOrder(application.Quotation, oNotes)
+		order, err := payments.CreateOrder(application.Quotation, oNotes, nil)
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "message": "Failed to Create Order"})
 			return

--- a/internal/trendlyapis/monetize/order.go
+++ b/internal/trendlyapis/monetize/order.go
@@ -86,7 +86,7 @@ func CreateOrder(c *gin.Context) {
 		order, err := payments.CreateOrder(application.Quotation, oNotes, []payments.OrderTransfer{
 			{
 				Account:  user.KYC.AccountID,
-				Amount:   (application.Quotation * 90) / 100,
+				Amount:   application.Quotation,
 				Currency: "INR",
 				OnHold:   myutil.BoolPtr(true),
 			},

--- a/internal/trendlyapis/monetize/order.go
+++ b/internal/trendlyapis/monetize/order.go
@@ -19,6 +19,18 @@ func CreateOrder(c *gin.Context) {
 		return
 	}
 
+	user := &trendlymodels.User{}
+	err = user.Get(data.Contract.UserID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "message": "Cant find User"})
+		return
+	}
+
+	if !user.IsKYCDone || user.KYC == nil || user.KYC.AccountID == "" || user.KYC.Status != "activated" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Influencer is not KYC verified", "message": "Influencer is not KYC verified"})
+		return
+	}
+
 	application := &trendlymodels.Application{}
 	err = application.Get(data.Contract.CollaborationID, data.Contract.UserID)
 	if err != nil {

--- a/internal/trendlyapis/monetize/order.go
+++ b/internal/trendlyapis/monetize/order.go
@@ -8,6 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/idivarts/backend-sls/internal/models/trendlymodels"
 	"github.com/idivarts/backend-sls/pkg/myemail"
+	"github.com/idivarts/backend-sls/pkg/myutil"
 	"github.com/idivarts/backend-sls/pkg/payments"
 	"github.com/idivarts/backend-sls/templates"
 )
@@ -39,6 +40,7 @@ func CreateOrder(c *gin.Context) {
 	}
 
 	var orderID string
+	var transferID string
 	var shortURL string
 	reuseOrder := false
 
@@ -81,12 +83,31 @@ func CreateOrder(c *gin.Context) {
 			"userId":          data.Contract.UserID,
 		}
 
-		order, err := payments.CreateOrder(application.Quotation, oNotes, nil)
+		order, err := payments.CreateOrder(application.Quotation, oNotes, []payments.OrderTransfer{
+			{
+				Account:  user.KYC.AccountID,
+				Amount:   (application.Quotation * 90) / 100,
+				Currency: "INR",
+				OnHold:   myutil.BoolPtr(true),
+			},
+		})
 		if err != nil {
 			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "message": "Failed to Create Order"})
 			return
 		}
+		if len(order.Transfers) == 0 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "No transfers found", "message": "Failed to Create Order with Transfers"})
+			return
+		}
+
+		orderTransfer := order.Transfers[0]
+		if orderTransfer.Error != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": orderTransfer.Error.Description, "message": "Failed to Create Order"})
+			return
+		}
+
 		orderID = order.ID
+		transferID = orderTransfer.ID
 
 		// 4. Create a Payment Link for the email
 		customerEmail := ""
@@ -112,10 +133,11 @@ func CreateOrder(c *gin.Context) {
 
 	// 5. Update the Contract with Order/Payment details
 	data.Contract.Payment = &trendlymodels.Payment{
-		OrderID:  orderID,
-		Status:   "waiting_for_payment",
-		ShortURL: shortURL,
-		Amount:   application.Quotation,
+		OrderID:    orderID,
+		TransferID: transferID,
+		Status:     "waiting_for_payment",
+		ShortURL:   shortURL,
+		Amount:     application.Quotation,
 	}
 	data.Contract.Status = trendlymodels.ContractStatusOrderCreated
 	err = data.Contract.Update(data.ContractID)

--- a/internal/trendlyapis/monetize/order.go
+++ b/internal/trendlyapis/monetize/order.go
@@ -1,6 +1,7 @@
 package monetize
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -10,6 +11,7 @@ import (
 	"github.com/idivarts/backend-sls/pkg/myemail"
 	"github.com/idivarts/backend-sls/pkg/myutil"
 	"github.com/idivarts/backend-sls/pkg/payments"
+	"github.com/idivarts/backend-sls/pkg/streamchat"
 	"github.com/idivarts/backend-sls/templates"
 )
 
@@ -17,6 +19,18 @@ func CreateOrder(c *gin.Context) {
 	data, err := initializeData(c)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to retrieve initialization data"})
+		return
+	}
+
+	application := &trendlymodels.Application{}
+	err = application.Get(data.Contract.CollaborationID, data.Contract.UserID)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "message": "Cant find Application"})
+		return
+	}
+
+	if application.Quotation <= 0 {
+		_ = startBarterContract(c, data, application)
 		return
 	}
 
@@ -29,13 +43,6 @@ func CreateOrder(c *gin.Context) {
 
 	if !user.IsKYCDone || user.KYC == nil || user.KYC.AccountID == "" || user.KYC.Status != "activated" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Influencer is not KYC verified", "message": "Influencer is not KYC verified"})
-		return
-	}
-
-	application := &trendlymodels.Application{}
-	err = application.Get(data.Contract.CollaborationID, data.Contract.UserID)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "message": "Cant find Application"})
 		return
 	}
 
@@ -175,6 +182,94 @@ func CreateOrder(c *gin.Context) {
 	})
 }
 
+// contractStatusAfterFunding matches handleOrderPaid in webhook_orders (post-payment workflow).
+func contractStatusAfterFunding(collab *trendlymodels.Collaboration) trendlymodels.ContractStatus {
+	if collab.PromotionSubject == trendlymodels.PromotionSubjectPhysicalProduct {
+		return trendlymodels.ContractStatusShipmentPending
+	}
+	return trendlymodels.ContractStatusDeliverablePending
+}
+
+// startBarterContract skips Razorpay for zero-quotation (barter) collabs and moves the contract forward
+// as if payment succeeded, without charging the brand.
+func startBarterContract(c *gin.Context, data *struct {
+	ContractID string
+	Contract   *trendlymodels.Contract
+	Brand      *trendlymodels.Brand
+}, _ *trendlymodels.Application) error {
+	collab := &trendlymodels.Collaboration{}
+	if err := collab.Get(data.Contract.CollaborationID); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error(), "message": "Cant find Collaboration"})
+		return err
+	}
+
+	nextStatus := contractStatusAfterFunding(collab)
+	data.Contract.Payment = &trendlymodels.Payment{
+		Status: "paid",
+		Amount: 0,
+	}
+	data.Contract.Status = nextStatus
+	if err := data.Contract.Update(data.ContractID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to update contract"})
+		return err
+	}
+
+	influencer := &trendlymodels.User{}
+	_ = influencer.Get(data.Contract.UserID)
+	influencerName := influencer.Name
+	if influencerName == "" {
+		influencerName = "Creator"
+	}
+	collabName := collab.Name
+	if collabName == "" {
+		collabName = "Your Collaboration"
+	}
+
+	notifBrand := &trendlymodels.Notification{
+		Title:       "Collaboration is live",
+		Description: fmt.Sprintf("%s is now active. No payment was required (barter). The creator can start the next steps.", collabName),
+		TimeStamp:   time.Now().UnixMilli(),
+		IsRead:      false,
+		Type:        "barter-collaboration-started",
+		Data: &trendlymodels.NotificationData{
+			CollaborationID: &data.Contract.CollaborationID,
+			GroupID:         &data.ContractID,
+		},
+	}
+	if _, _, err := notifBrand.Insert(trendlymodels.BRAND_COLLECTION, data.Contract.BrandID); err != nil {
+		log.Printf("barter start: brand notification: %v", err)
+	}
+
+	notifInfluencer := &trendlymodels.Notification{
+		Title:       "Collaboration is live",
+		Description: fmt.Sprintf("Your barter collaboration %s with %s is active. You can start working on the next steps.", collabName, data.Brand.Name),
+		TimeStamp:   time.Now().UnixMilli(),
+		IsRead:      false,
+		Type:        "barter-collaboration-started",
+		Data: &trendlymodels.NotificationData{
+			CollaborationID: &data.Contract.CollaborationID,
+			GroupID:         &data.ContractID,
+		},
+	}
+	if _, _, err := notifInfluencer.Insert(trendlymodels.USER_COLLECTION, data.Contract.UserID); err != nil {
+		log.Printf("barter start: influencer notification: %v", err)
+	}
+
+	streamMessage := fmt.Sprintf("🤝 **Barter collaboration is live**\n\nNo payment was required. **%s** and **%s** can move forward with the collaboration. 🚀", data.Brand.Name, influencerName)
+	if err := streamchat.SendSystemMessage(data.Contract.StreamChannelID, streamMessage); err != nil {
+		log.Printf("barter start: stream message: %v", err)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"message":  "Barter collaboration started",
+		"barter":   true,
+		"status":   int(nextStatus),
+		"orderId":  "",
+		"shortUrl": "",
+	})
+	return nil
+}
+
 func GetOrder(c *gin.Context) {
 	data, err := initializeData(c)
 	if err != nil {
@@ -182,7 +277,21 @@ func GetOrder(c *gin.Context) {
 		return
 	}
 
-	if data.Contract.Payment == nil || data.Contract.Payment.OrderID == "" {
+	if data.Contract.Payment == nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "No order found", "message": "No payment order has been created for this contract yet"})
+		return
+	}
+
+	if data.Contract.Payment.OrderID == "" && data.Contract.Payment.Status == "paid" && data.Contract.Payment.Amount == 0 {
+		c.JSON(http.StatusOK, gin.H{
+			"message": "Barter collaboration — no Razorpay order",
+			"barter":  true,
+			"payment": data.Contract.Payment,
+		})
+		return
+	}
+
+	if data.Contract.Payment.OrderID == "" {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "No order found", "message": "No payment order has been created for this contract yet"})
 		return
 	}

--- a/internal/trendlyapis/monetize/posting.go
+++ b/internal/trendlyapis/monetize/posting.go
@@ -10,6 +10,7 @@ import (
 	"github.com/idivarts/backend-sls/internal/constants"
 	"github.com/idivarts/backend-sls/internal/models/trendlymodels"
 	"github.com/idivarts/backend-sls/pkg/myemail"
+	"github.com/idivarts/backend-sls/pkg/payments"
 	"github.com/idivarts/backend-sls/pkg/streamchat"
 	"github.com/idivarts/backend-sls/templates"
 )
@@ -109,6 +110,15 @@ type MarkPostedReq struct {
 	Notes           string `json:"notes"`
 }
 
+func releasePaymentAfterHoldingForDay(contract trendlymodels.Contract, days int) error {
+	if contract.Payment == nil || contract.Payment.TransferID == "" {
+		return fmt.Errorf("payment not found")
+	}
+
+	_, err := payments.UpdateTransferHold(contract.Payment.TransferID, days)
+	return err
+}
+
 func MarkPosted(c *gin.Context) {
 	var req MarkPostedReq
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -135,6 +145,12 @@ func MarkPosted(c *gin.Context) {
 	err = data.Contract.Update(data.ContractID)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to update contract"})
+		return
+	}
+
+	err = releasePaymentAfterHoldingForDay(*data.Contract, 2)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to release payment after holding for day"})
 		return
 	}
 

--- a/internal/trendlyapis/monetize/posting.go
+++ b/internal/trendlyapis/monetize/posting.go
@@ -119,6 +119,93 @@ func releasePaymentAfterHoldingForDay(contract trendlymodels.Contract, days int)
 	return err
 }
 
+func notifyAboutContractEnded(contractID string, contract trendlymodels.Contract) error {
+	brand := &trendlymodels.Brand{}
+	if err := brand.Get(contract.BrandID); err != nil {
+		return fmt.Errorf("get brand: %w", err)
+	}
+	influencer := &trendlymodels.User{}
+	if err := influencer.Get(contract.UserID); err != nil {
+		return fmt.Errorf("get influencer: %w", err)
+	}
+	collab := &trendlymodels.Collaboration{}
+	if err := collab.Get(contract.CollaborationID); err != nil {
+		return fmt.Errorf("get collaboration: %w", err)
+	}
+
+	collabName := collab.Name
+	if collabName == "" {
+		collabName = "Your Collaboration"
+	}
+	endDate := time.Now().Format("Jan 02, 2006")
+	ratingLink := fmt.Sprintf("%s/contract-details/%s", constants.GetCreatorsFronted(), contractID)
+
+	// In-app + push (Insert)
+	notifBrand := &trendlymodels.Notification{
+		Title:       "Collaboration complete",
+		Description: fmt.Sprintf("The contract for %s is complete. Thank you for collaborating with %s.", collabName, influencer.Name),
+		TimeStamp:   time.Now().UnixMilli(),
+		IsRead:      false,
+		Type:        "contract-ended",
+		Data: &trendlymodels.NotificationData{
+			CollaborationID: &contract.CollaborationID,
+			GroupID:         &contractID,
+		},
+	}
+	_, brandEmails, err := notifBrand.Insert(trendlymodels.BRAND_COLLECTION, contract.BrandID)
+	if err != nil {
+		log.Printf("contract ended: brand notification: %v", err)
+	}
+
+	notifInfluencer := &trendlymodels.Notification{
+		Title:       "Collaboration complete",
+		Description: fmt.Sprintf("Your collaboration %s with %s is complete. Rate the brand to see their rating.", collabName, brand.Name),
+		TimeStamp:   time.Now().UnixMilli(),
+		IsRead:      false,
+		Type:        "contract-ended",
+		Data: &trendlymodels.NotificationData{
+			CollaborationID: &contract.CollaborationID,
+			GroupID:         &contractID,
+		},
+	}
+	if _, _, err := notifInfluencer.Insert(trendlymodels.USER_COLLECTION, contract.UserID); err != nil {
+		log.Printf("contract ended: influencer notification: %v", err)
+	}
+
+	// Email
+	if len(brandEmails) > 0 {
+		emailBrand := map[string]interface{}{
+			"BrandMemberName": brand.Name,
+			"InfluencerName":  influencer.Name,
+			"CollabTitle":     collabName,
+			"EndDate":         endDate,
+		}
+		if err := myemail.SendCustomHTMLEmailToMultipleRecipients(brandEmails, templates.CollaborationEndedBrand, templates.SubjectContractEndedForBrand, emailBrand); err != nil {
+			log.Printf("contract ended: brand email: %v", err)
+		}
+	}
+	if influencer.Email != nil && *influencer.Email != "" {
+		emailInfluencer := map[string]interface{}{
+			"InfluencerName": influencer.Name,
+			"BrandName":      brand.Name,
+			"CollabTitle":    collabName,
+			"EndDate":        endDate,
+			"RatingLink":     ratingLink,
+		}
+		if err := myemail.SendCustomHTMLEmail(*influencer.Email, templates.CollaborationEndedInfluencer, templates.SubjectContractEndedForInfluencer, emailInfluencer); err != nil {
+			log.Printf("contract ended: influencer email: %v", err)
+		}
+	}
+
+	// Stream
+	streamMsg := fmt.Sprintf("🏁 **Collaboration complete**\n\nThe contract for **%s** is closed. You can leave ratings in the app when you’re ready. Thank you both! ✨", collabName)
+	if err := streamchat.SendSystemMessage(contract.StreamChannelID, streamMsg); err != nil {
+		log.Printf("contract ended: stream: %v", err)
+	}
+
+	return nil
+}
+
 func MarkPosted(c *gin.Context) {
 	var req MarkPostedReq
 	if err := c.ShouldBindJSON(&req); err != nil {
@@ -140,7 +227,11 @@ func MarkPosted(c *gin.Context) {
 	data.Contract.Posting.PostURL = req.PostURL
 	data.Contract.Posting.Notes = req.Notes
 	data.Contract.Posting.Status = "posted"
-	data.Contract.Status = trendlymodels.ContractStatusPostDone
+	if data.Contract.Payment != nil && data.Contract.Payment.Status == "paid" && data.Contract.Payment.Amount == 0 {
+		data.Contract.Status = trendlymodels.ContractStatusSettled
+	} else {
+		data.Contract.Status = trendlymodels.ContractStatusPostDone
+	}
 
 	err = data.Contract.Update(data.ContractID)
 	if err != nil {
@@ -148,9 +239,21 @@ func MarkPosted(c *gin.Context) {
 		return
 	}
 
-	err = releasePaymentAfterHoldingForDay(*data.Contract, 2)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to release payment after holding for day"})
+	if data.Contract.Status == trendlymodels.ContractStatusPostDone {
+		err = releasePaymentAfterHoldingForDay(*data.Contract, 2)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error(), "message": "Failed to release payment after holding for day"})
+			return
+		}
+	}
+	if data.Contract.Status == trendlymodels.ContractStatusSettled {
+		if err := notifyAboutContractEnded(data.ContractID, *data.Contract); err != nil {
+			log.Printf("notify contract ended: %v", err)
+		}
+		c.JSON(http.StatusOK, gin.H{
+			"message":         "Post marked as live successfully",
+			"contractSettled": true,
+		})
 		return
 	}
 

--- a/internal/trendlyapis/monetize/webhook_transfers.go
+++ b/internal/trendlyapis/monetize/webhook_transfers.go
@@ -116,6 +116,10 @@ func handleTransferProcessed(transfer *webhook.TransferEntity) {
 		log.Printf("transfer processed: contract %s order mismatch (webhook order %s, contract order %s)", contractID, orderID, contract.Payment.OrderID)
 		return
 	}
+	if contract.Payment != nil && contract.Payment.TransferID != "" && contract.Payment.TransferID != transferID {
+		log.Printf("transfer processed: contract %s transfer mismatch (webhook transfer %s, contract transfer %s)", contractID, transferID, contract.Payment.TransferID)
+		return
+	}
 
 	// 2. Update Contract Status to Settled (10)
 	if contract.Payment == nil {
@@ -224,6 +228,10 @@ func handleTransferFailed(transfer *webhook.TransferEntity) {
 
 	if contract.Status == trendlymodels.ContractStatusSettled {
 		log.Printf("transfer failed: skip contract %s already settled (transfer %s)", contractID, transferID)
+		return
+	}
+	if contract.Payment != nil && contract.Payment.TransferID != "" && contract.Payment.TransferID != transferID {
+		log.Printf("transfer processed: contract %s transfer mismatch (webhook transfer %s, contract transfer %s)", contractID, transferID, contract.Payment.TransferID)
 		return
 	}
 

--- a/pkg/payments/orders.go
+++ b/pkg/payments/orders.go
@@ -35,14 +35,53 @@ func MapToOrder(m map[string]interface{}) (*Order, error) {
 	return &order, nil
 }
 
-func CreateOrder(amountInRs int, notes map[string]interface{}) (*Order, error) {
+// OrderTransfer is one linked-account transfer embedded in order creation (Razorpay Route / order API).
+// Amount is in the smallest currency unit (paise for INR), consistent with the order amount field.
+type OrderTransfer struct {
+	Account            string                 `json:"account"`
+	Amount             int                    `json:"amount"`
+	Currency           string                 `json:"currency"`
+	Notes              map[string]interface{} `json:"notes,omitempty"`
+	LinkedAccountNotes []string               `json:"linked_account_notes,omitempty"`
+	OnHold             *bool                  `json:"on_hold,omitempty"`
+	OnHoldUntil        *int64                 `json:"on_hold_until,omitempty"`
+}
+
+func CreateOrder(amountInRs int, notes map[string]interface{}, transfers []OrderTransfer) (*Order, error) {
 	// This function will handle the creation of an order.
 	// It will interact with Razorpay's API to create an order and return the order details.
+	// Pass nil or an empty transfers slice to omit "transfers" from the payload.
 
 	data := map[string]interface{}{
 		"amount":   amountInRs * 100, // amount in paise
 		"currency": "INR",
 		"notes":    notes,
+	}
+
+	if len(transfers) > 0 {
+		payload := make([]map[string]interface{}, 0, len(transfers))
+		for i := range transfers {
+			t := transfers[i]
+			m := map[string]interface{}{
+				"account":  t.Account,
+				"amount":   t.Amount,
+				"currency": t.Currency,
+			}
+			if len(t.Notes) > 0 {
+				m["notes"] = t.Notes
+			}
+			if len(t.LinkedAccountNotes) > 0 {
+				m["linked_account_notes"] = t.LinkedAccountNotes
+			}
+			if t.OnHold != nil {
+				m["on_hold"] = *t.OnHold
+			}
+			if t.OnHoldUntil != nil {
+				m["on_hold_until"] = *t.OnHoldUntil
+			}
+			payload = append(payload, m)
+		}
+		data["transfers"] = payload
 	}
 
 	res, err := Client.Order.Create(data, nil)

--- a/pkg/payments/orders.go
+++ b/pkg/payments/orders.go
@@ -69,7 +69,7 @@ func MapToOrder(m map[string]interface{}) (*Order, error) {
 }
 
 // OrderTransfer is one linked-account transfer embedded in order creation (Razorpay Route / order API).
-// Amount is in the smallest currency unit (paise for INR), consistent with the order amount field.
+// Amount is in whole rupees (same unit as CreateOrder’s amountInRs); CreateOrder sends amount*100 as paise to Razorpay.
 type OrderTransfer struct {
 	Account            string                 `json:"account"`
 	Amount             int                    `json:"amount"`

--- a/pkg/payments/orders.go
+++ b/pkg/payments/orders.go
@@ -8,17 +8,50 @@ import (
 )
 
 type Order struct {
-	ID         string                 `json:"id"`
-	Entity     string                 `json:"entity"`
-	Amount     int                    `json:"amount"`
-	AmountPaid int                    `json:"amount_paid"`
-	AmountDue  int                    `json:"amount_due"`
-	Currency   string                 `json:"currency"`
-	Receipt    string                 `json:"receipt"`
-	Status     string                 `json:"status"`
-	Attempts   int                    `json:"attempts"`
-	Notes      map[string]interface{} `json:"notes"`
-	CreatedAt  int64                  `json:"created_at"`
+	ID         string                  `json:"id"`
+	Entity     string                  `json:"entity"`
+	Amount     int                     `json:"amount"`
+	AmountPaid int                     `json:"amount_paid"`
+	AmountDue  int                     `json:"amount_due"`
+	Currency   string                  `json:"currency"`
+	Receipt    string                  `json:"receipt"`
+	Status     string                  `json:"status"`
+	Attempts   int                     `json:"attempts"`
+	Notes      map[string]interface{}  `json:"notes"`
+	CreatedAt  int64                   `json:"created_at"`
+	Transfers  []OrderTransferResponse `json:"transfers,omitempty"`
+}
+
+// OrderTransferError is the nested error object on transfers returned with an order.
+type OrderTransferError struct {
+	Code        *string     `json:"code"`
+	Description *string     `json:"description"`
+	Reason      *string     `json:"reason"`
+	Field       *string     `json:"field"`
+	Step        *string     `json:"step"`
+	ID          *string     `json:"id"`
+	Source      *string     `json:"source"`
+	Metadata    interface{} `json:"metadata"`
+}
+
+// OrderTransferResponse is one Route transfer returned on order create/fetch (recipient, status, etc.).
+type OrderTransferResponse struct {
+	ID                    string                 `json:"id"`
+	Entity                string                 `json:"entity"`
+	Status                string                 `json:"status"`
+	Source                string                 `json:"source"`
+	Recipient             string                 `json:"recipient"`
+	Amount                int                    `json:"amount"`
+	Currency              string                 `json:"currency"`
+	AmountReversed        int                    `json:"amount_reversed"`
+	Notes                 map[string]interface{} `json:"notes,omitempty"`
+	LinkedAccountNotes    []string               `json:"linked_account_notes,omitempty"`
+	OnHold                bool                   `json:"on_hold"`
+	OnHoldUntil           *int64                 `json:"on_hold_until,omitempty"`
+	RecipientSettlementID *string                `json:"recipient_settlement_id,omitempty"`
+	CreatedAt             int64                  `json:"created_at"`
+	ProcessedAt           *int64                 `json:"processed_at,omitempty"`
+	Error                 *OrderTransferError    `json:"error,omitempty"`
 }
 
 func MapToOrder(m map[string]interface{}) (*Order, error) {
@@ -64,8 +97,8 @@ func CreateOrder(amountInRs int, notes map[string]interface{}, transfers []Order
 			t := transfers[i]
 			m := map[string]interface{}{
 				"account":  t.Account,
-				"amount":   t.Amount,
-				"currency": t.Currency,
+				"amount":   t.Amount * 100,
+				"currency": "INR",
 			}
 			if len(t.Notes) > 0 {
 				m["notes"] = t.Notes

--- a/pkg/payments/orders.go
+++ b/pkg/payments/orders.go
@@ -72,7 +72,7 @@ func MapToOrder(m map[string]interface{}) (*Order, error) {
 // Amount is in whole rupees (same unit as CreateOrder’s amountInRs); CreateOrder sends amount*100 as paise to Razorpay.
 type OrderTransfer struct {
 	Account            string                 `json:"account"`
-	Amount             int                    `json:"amount"`
+	AmountInRs         int                    `json:"amount"`
 	Currency           string                 `json:"currency"`
 	Notes              map[string]interface{} `json:"notes,omitempty"`
 	LinkedAccountNotes []string               `json:"linked_account_notes,omitempty"`
@@ -97,7 +97,7 @@ func CreateOrder(amountInRs int, notes map[string]interface{}, transfers []Order
 			t := transfers[i]
 			m := map[string]interface{}{
 				"account":  t.Account,
-				"amount":   t.Amount * 100,
+				"amount":   t.AmountInRs * 100,
 				"currency": "INR",
 			}
 			if len(t.Notes) > 0 {

--- a/pkg/payments/payments_test.go
+++ b/pkg/payments/payments_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestCreateOrder(t *testing.T) {
-	payments.CreateOrder(499, map[string]interface{}{})
+	payments.CreateOrder(499, map[string]interface{}{}, nil)
 }
 
 func TestCreatePaymentLink(t *testing.T) {

--- a/pkg/payments/transfers.go
+++ b/pkg/payments/transfers.go
@@ -1,0 +1,33 @@
+package payments
+
+import (
+	"fmt"
+	"time"
+)
+
+// UpdateTransferHold updates Razorpay Route transfer settlement hold (PATCH /v1/transfers/:id).
+//
+// If holdDays <= 0, the hold is released (on_hold=false) so settlement can proceed per Razorpay rules.
+//
+// If holdDays > 0, the transfer remains on hold until on_hold_until, set to holdDays calendar
+// days from now in the local timezone (same semantics as time.Now().AddDate(0, 0, holdDays)).
+func UpdateTransferHold(transferID string, holdDays int) (map[string]interface{}, error) {
+	if transferID == "" {
+		return nil, fmt.Errorf("empty transfer id")
+	}
+
+	var data map[string]interface{}
+	if holdDays <= 0 {
+		data = map[string]interface{}{
+			"on_hold": false,
+		}
+	} else {
+		until := time.Now().AddDate(0, 0, holdDays).Unix()
+		data = map[string]interface{}{
+			"on_hold":       true,
+			"on_hold_until": until,
+		}
+	}
+
+	return Client.Transfer.Edit(transferID, data, nil)
+}

--- a/templates/end_contract_brand.html
+++ b/templates/end_contract_brand.html
@@ -4,6 +4,7 @@
     {{.InfluencerName}}    => Name of the influencer whose contract was ended
     {{.CollabTitle}}       => Title of the collaboration
     {{.EndDate}}           => Date the contract was ended
+  (Brand is prompted to submit a rating; copy assumes feedback is not yet submitted.)
 -->
 
 <!DOCTYPE html>
@@ -50,11 +51,9 @@
             <strong>{{.InfluencerName}}</strong> on <strong>{{.EndDate}}</strong>.
         </p>
 
-        <p>Thank you for submitting your rating for the influencer. Your feedback helps maintain a high standard across
-            our platform.</p>
+        <p>Please take a moment to <strong>rate {{.InfluencerName}}</strong> in Trendly. Your feedback helps keep collaborations fair and high quality for everyone.</p>
 
-        <p><strong>Note:</strong> To ensure fairness, your rating will remain hidden until the influencer also rates
-            you. We’ll notify you once they submit their review.</p>
+        <p><strong>Note:</strong> For fairness, your rating stays hidden until the influencer rates you too. We’ll notify you when they submit their review.</p>
 
         <div class="footer">
             You're receiving this email because you're involved in a collaboration on Trendly.<br />


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches payment creation and settlement flow (Razorpay orders/transfers, KYC gating, and contract status transitions), so mistakes could block payouts or prematurely settle contracts. Changes are localized but span order creation, posting/deliverable approval, and transfer webhooks.
> 
> **Overview**
> Adds Razorpay Route *linked-account transfers* to order creation, storing `Payment.TransferID`, enforcing influencer KYC before paid orders, and introducing a hold/release mechanism via `payments.UpdateTransferHold`.
> 
> Introduces a **barter (zero-quotation) flow** that skips Razorpay, marks payment as `paid` with `Amount=0`, advances the contract to the post-funding status, and updates `GetOrder`/posting/deliverable endpoints to treat barter contracts as immediately `Settled` and send “collaboration complete” notifications.
> 
> Hardens transfer webhooks by validating `transferId` matches the contract before marking the contract `Settled`, and updates the brand contract-ended email copy to prompt for rating.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0f1712be1e02dca37be58a5a55eeaea5e57aab9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->